### PR TITLE
Apply rounding to cost variable, not accumulator

### DIFF
--- a/src/Recipe.js
+++ b/src/Recipe.js
@@ -21,10 +21,10 @@ class Recipe {
     const cost = this.ingredients.reduce((totalCost, ingredient) => {
       const findCost = ingredientsData.find(element => ingredient.id === element.id);
       const estimatedCostInDollars = (findCost.estimatedCostInCents * ingredient.quantity.amount) / 100;
-      return totalCost + Number((estimatedCostInDollars).toFixed(2));
+      return totalCost + estimatedCostInDollars
     }, 0)
 
-    return cost
+    return Math.round(cost * 100) / 100; 
   }
 
   getInstructions() {

--- a/tests/Recipe-tests.js
+++ b/tests/Recipe-tests.js
@@ -52,7 +52,7 @@ describe('Recipe', () => {
   });
 
   it('should be able to calculate the total cost of ingredients required', () => {
-    expect(recipe.getTotalCostOfIngredients()).to.equal(177.75);
+    expect(recipe.getTotalCostOfIngredients()).to.equal(177.76);
   });
 
   it('should be able to return recipe\'s instructions', () => {


### PR DESCRIPTION
## Is this a fix or a feature? ⬇️
+ Fix


## What is the change? ⬇️
+ Rounds the return value of getTotalCostOfIngredients, rather than the accumulator value of the reduce method.


## What does it fix? ⬇️
+ Consistently rounds the total cost to the nearest hundredth.


## Where should the reviewer start? ⬇️
+ src/Recipe.js - lines 20 - 28, getTotalCostOfIngredients


## How should this be tested? ⬇️
+ Should pass test "should be able to calculate the total cost of ingredients required"